### PR TITLE
Change to use PSR-4 namespaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/.idea
+/vendor

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ php:
   - 5.5
   - 5.6
   - 7.0
-install: pear install Net_URL2
 addons:
   hosts:
     - hr2.local

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require"     : {
         "php"                 : ">=5.2.0",
         "pear/net_url2"       : "^2.2.0",
-        "pear/pear_exception" : "^1.0.0"
+        "pear/pear_exception" : "^1.0"
     },
     "suggest"     : {
         "ext-fileinfo" : "Adds support for looking up mime-types using finfo.",
@@ -27,8 +27,9 @@
         "lib-openssl"  : "Allows handling SSL requests when not using cURL."
     },
     "autoload": {
-        "psr-0": {
-            "HTTP_Request2" : ""
+        "psr-4": {
+            "FINDOLOGIC\\HTTP_Request2\\" : "src/FINDOLOGIC/HTTP_Request2/",
+            "FINDOLOGIC\\HTTP_Request2\\Tests\\" : "tests/"
         }
     },
     "include-path": [
@@ -38,5 +39,8 @@
         "branch-alias": {
             "dev-trunk": "2.2-dev"
         }
+    },
+    "require-dev": {
+        "phpunit/phpunit": "v4"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,769 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "ea78355630b154a2df1195d1bb292cf6",
+    "packages": [
+        {
+            "name": "pear/net_url2",
+            "version": "v2.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pear/Net_URL2.git",
+                "reference": "07fd055820dbf466ee3990abe96d0e40a8791f9d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pear/Net_URL2/zipball/07fd055820dbf466ee3990abe96d0e40a8791f9d",
+                "reference": "07fd055820dbf466ee3990abe96d0e40a8791f9d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.1.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": ">=3.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "Net/URL2.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                "./"
+            ],
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "David Coallier",
+                    "email": "davidc@php.net"
+                },
+                {
+                    "name": "Tom Klingenberg",
+                    "email": "tkli@php.net"
+                },
+                {
+                    "name": "Christian Schmidt",
+                    "email": "chmidt@php.net"
+                }
+            ],
+            "description": "Class for parsing and handling URL. Provides parsing of URLs into their constituent parts (scheme, host, path etc.), URL generation, and resolving of relative URLs.",
+            "homepage": "https://github.com/pear/Net_URL2",
+            "keywords": [
+                "PEAR",
+                "net",
+                "networking",
+                "rfc3986",
+                "uri",
+                "url"
+            ],
+            "time": "2017-08-25T06:16:11+00:00"
+        },
+        {
+            "name": "pear/pear_exception",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pear/PEAR_Exception.git",
+                "reference": "8c18719fdae000b690e3912be401c76e406dd13b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pear/PEAR_Exception/zipball/8c18719fdae000b690e3912be401c76e406dd13b",
+                "reference": "8c18719fdae000b690e3912be401c76e406dd13b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=4.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "*"
+            },
+            "type": "class",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "PEAR": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                "."
+            ],
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Helgi Thormar",
+                    "email": "dufuz@php.net"
+                },
+                {
+                    "name": "Greg Beaver",
+                    "email": "cellog@php.net"
+                }
+            ],
+            "description": "The PEAR Exception base class.",
+            "homepage": "https://github.com/pear/PEAR_Exception",
+            "keywords": [
+                "exception"
+            ],
+            "time": "2015-02-10T20:07:52+00:00"
+        }
+    ],
+    "packages-dev": [
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "2.0.17",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "c4e8e7725e351184a76544634855b8a9c405a6e3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/c4e8e7725e351184a76544634855b8a9c405a6e3",
+                "reference": "c4e8e7725e351184a76544634855b8a9c405a6e3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "phpunit/php-file-iterator": "~1.3",
+                "phpunit/php-text-template": "~1.2",
+                "phpunit/php-token-stream": "~1.3",
+                "sebastian/environment": "~1.0",
+                "sebastian/version": "~1.0"
+            },
+            "require-dev": {
+                "ext-xdebug": ">=2.1.4",
+                "phpunit/phpunit": "~4"
+            },
+            "suggest": {
+                "ext-dom": "*",
+                "ext-xdebug": ">=2.2.1",
+                "ext-xmlwriter": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "time": "2015-05-25T05:11:59+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "1.3.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "acd690379117b042d1c8af1fafd61bde001bf6bb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/acd690379117b042d1c8af1fafd61bde001bf6bb",
+                "reference": "acd690379117b042d1c8af1fafd61bde001bf6bb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "File/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                ""
+            ],
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "time": "2013-10-10T15:34:57+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "time": "2015-06-21T13:50:34+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "1.0.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
+                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "time": "2017-02-26T11:10:40+00:00"
+        },
+        {
+            "name": "phpunit/php-token-stream",
+            "version": "1.4.12",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-token-stream.git",
+                "reference": "1ce90ba27c42e4e44e6d8458241466380b51fa16"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/1ce90ba27c42e4e44e6d8458241466380b51fa16",
+                "reference": "1ce90ba27c42e4e44e6d8458241466380b51fa16",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Wrapper around PHP's tokenizer extension.",
+            "homepage": "https://github.com/sebastianbergmann/php-token-stream/",
+            "keywords": [
+                "tokenizer"
+            ],
+            "time": "2017-12-04T08:55:13+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "b3a7c58bc39f01577f89d63da1ec578e1e993f1a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b3a7c58bc39f01577f89d63da1ec578e1e993f1a",
+                "reference": "b3a7c58bc39f01577f89d63da1ec578e1e993f1a",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-pcre": "*",
+                "ext-reflection": "*",
+                "ext-spl": "*",
+                "php": ">=5.3.3",
+                "phpunit/php-code-coverage": ">=2.0.0,<2.1.0",
+                "phpunit/php-file-iterator": "~1.3.1",
+                "phpunit/php-text-template": "~1.2",
+                "phpunit/php-timer": "~1.0.2",
+                "phpunit/phpunit-mock-objects": ">=2.0.0,<2.1.0",
+                "sebastian/diff": "~1.1",
+                "sebastian/environment": "~1.0",
+                "sebastian/exporter": "~1.0.1",
+                "sebastian/version": "~1.0",
+                "symfony/yaml": "~2.0"
+            },
+            "suggest": {
+                "ext-json": "*",
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "phpunit/php-invoker": "~1.1"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                "",
+                "../../symfony/yaml/"
+            ],
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "http://www.phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "time": "2014-03-07T07:00:44+00:00"
+        },
+        {
+            "name": "phpunit/phpunit-mock-objects",
+            "version": "2.0.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
+                "reference": "e60bb929c50ae4237aaf680a4f6773f4ee17f0a2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/e60bb929c50ae4237aaf680a4f6773f4ee17f0a2",
+                "reference": "e60bb929c50ae4237aaf680a4f6773f4ee17f0a2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "phpunit/php-text-template": "~1.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": ">=4.0.0,<4.1.0"
+            },
+            "suggest": {
+                "ext-soap": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                ""
+            ],
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Mock Object library for PHPUnit",
+            "homepage": "https://github.com/sebastianbergmann/phpunit-mock-objects/",
+            "keywords": [
+                "mock",
+                "xunit"
+            ],
+            "time": "2014-06-12T07:19:48+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "1.4.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/7f066a26a962dbe58ddea9f72a4e82874a3975a4",
+                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff"
+            ],
+            "time": "2017-05-22T07:24:03+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "1.3.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "be2c607e43ce4c89ecd60e75c6a85c126e754aea"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/be2c607e43ce4c89ecd60e75c6a85c126e754aea",
+                "reference": "be2c607e43ce4c89ecd60e75c6a85c126e754aea",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8 || ^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "time": "2016-08-18T05:49:44+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "c7d59948d6e82818e1bdff7cadb6c34710eb7dc0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/c7d59948d6e82818e1bdff7cadb6c34710eb7dc0",
+                "reference": "c7d59948d6e82818e1bdff7cadb6c34710eb7dc0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "http://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "time": "2014-09-10T00:51:36+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "1.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
+                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "time": "2015-06-21T13:59:46+00:00"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v2.8.32",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "968ef42161e4bc04200119da473077f9e7015128"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/968ef42161e4bc04200119da473077f9e7015128",
+                "reference": "968ef42161e4bc04200119da473077f9e7015128",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.8-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Yaml Component",
+            "homepage": "https://symfony.com",
+            "time": "2017-11-29T09:33:18+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": ">=5.2.0"
+    },
+    "platform-dev": []
+}

--- a/src/FINDOLOGIC/HTTP_Request2/Adapter.php
+++ b/src/FINDOLOGIC/HTTP_Request2/Adapter.php
@@ -18,10 +18,7 @@
  * @link      http://pear.php.net/package/HTTP_Request2
  */
 
-/**
- * Class representing a HTTP response
- */
-require_once 'HTTP/Request2/Response.php';
+namespace FINDOLOGIC\HTTP_Request2;
 
 /**
  * Base class for HTTP_Request2 adapters

--- a/src/FINDOLOGIC/HTTP_Request2/Adapter/Curl.php
+++ b/src/FINDOLOGIC/HTTP_Request2/Adapter/Curl.php
@@ -18,10 +18,16 @@
  * @link      http://pear.php.net/package/HTTP_Request2
  */
 
-/**
- * Base class for HTTP_Request2 adapters
- */
-require_once 'HTTP/Request2/Adapter.php';
+namespace FINDOLOGIC\HTTP_Request2\Adapter;
+
+use Exception;
+use FINDOLOGIC\HTTP_Request2\HTTP_Request2;
+use FINDOLOGIC\HTTP_Request2\HTTP_Request2_Adapter;
+use FINDOLOGIC\HTTP_Request2\HTTP_Request2_Exception;
+use FINDOLOGIC\HTTP_Request2\HTTP_Request2_LogicException;
+use FINDOLOGIC\HTTP_Request2\HTTP_Request2_MessageException;
+use FINDOLOGIC\HTTP_Request2\HTTP_Request2_NotImplementedException;
+use FINDOLOGIC\HTTP_Request2\HTTP_Request2_Response;
 
 /**
  * Adapter for HTTP_Request2 wrapping around cURL extension

--- a/src/FINDOLOGIC/HTTP_Request2/Adapter/Mock.php
+++ b/src/FINDOLOGIC/HTTP_Request2/Adapter/Mock.php
@@ -18,10 +18,12 @@
  * @link      http://pear.php.net/package/HTTP_Request2
  */
 
-/**
- * Base class for HTTP_Request2 adapters
- */
-require_once 'HTTP/Request2/Adapter.php';
+namespace FINDOLOGIC\HTTP_Request2\Adapter;
+use Exception;
+use FINDOLOGIC\HTTP_Request2\HTTP_Request2;
+use FINDOLOGIC\HTTP_Request2\HTTP_Request2_Adapter;
+use FINDOLOGIC\HTTP_Request2\HTTP_Request2_Exception;
+use FINDOLOGIC\HTTP_Request2\HTTP_Request2_Response;
 
 /**
  * Mock adapter intended for testing

--- a/src/FINDOLOGIC/HTTP_Request2/Adapter/Socket.php
+++ b/src/FINDOLOGIC/HTTP_Request2/Adapter/Socket.php
@@ -18,11 +18,19 @@
  * @link      http://pear.php.net/package/HTTP_Request2
  */
 
-/** Base class for HTTP_Request2 adapters */
-require_once 'HTTP/Request2/Adapter.php';
-
-/** Socket wrapper class */
-require_once 'HTTP/Request2/SocketWrapper.php';
+namespace FINDOLOGIC\HTTP_Request2\Adapter;
+use Exception;
+use FINDOLOGIC\HTTP_Request2\HTTP_Request2;
+use FINDOLOGIC\HTTP_Request2\HTTP_Request2_Adapter;
+use FINDOLOGIC\HTTP_Request2\HTTP_Request2_ConnectionException;
+use FINDOLOGIC\HTTP_Request2\HTTP_Request2_Exception;
+use FINDOLOGIC\HTTP_Request2\HTTP_Request2_LogicException;
+use FINDOLOGIC\HTTP_Request2\HTTP_Request2_MessageException;
+use FINDOLOGIC\HTTP_Request2\HTTP_Request2_NotImplementedException;
+use FINDOLOGIC\HTTP_Request2\HTTP_Request2_Response;
+use FINDOLOGIC\HTTP_Request2\HTTP_Request2_SocketWrapper;
+use FINDOLOGIC\HTTP_Request2\HTTP_Request2_SOCKS5;
+use Net_URL2;
 
 /**
  * Socket-based adapter for HTTP_Request2
@@ -305,8 +313,6 @@ class HTTP_Request2_Adapter_Socket extends HTTP_Request2_Adapter
 
         } else {
             if ($socksProxy) {
-                require_once 'HTTP/Request2/SOCKS5.php';
-
                 $this->socket = new HTTP_Request2_SOCKS5(
                     $remote, $this->request->getConfig('connect_timeout'),
                     $options, $this->request->getConfig('proxy_user'),

--- a/src/FINDOLOGIC/HTTP_Request2/CookieJar.php
+++ b/src/FINDOLOGIC/HTTP_Request2/CookieJar.php
@@ -18,8 +18,13 @@
  * @link      http://pear.php.net/package/HTTP_Request2
  */
 
-/** Class representing a HTTP request message */
-require_once 'HTTP/Request2.php';
+namespace FINDOLOGIC\HTTP_Request2;
+
+use DateTime;
+use DateTimeZone;
+use Exception;
+use Net_URL2;
+use Serializable;
 
 /**
  * Stores cookies and passes them between HTTP requests

--- a/src/FINDOLOGIC/HTTP_Request2/Exception.php
+++ b/src/FINDOLOGIC/HTTP_Request2/Exception.php
@@ -18,10 +18,9 @@
  * @link      http://pear.php.net/package/HTTP_Request2
  */
 
-/**
- * Base class for exceptions in PEAR
- */
-require_once 'PEAR/Exception.php';
+namespace FINDOLOGIC\HTTP_Request2;
+
+use PEAR_Exception;
 
 /**
  * Base exception class for HTTP_Request2 package

--- a/src/FINDOLOGIC/HTTP_Request2/MultipartBody.php
+++ b/src/FINDOLOGIC/HTTP_Request2/MultipartBody.php
@@ -18,8 +18,7 @@
  * @link      http://pear.php.net/package/HTTP_Request2
  */
 
-/** Exception class for HTTP_Request2 package */
-require_once 'HTTP/Request2/Exception.php';
+namespace FINDOLOGIC\HTTP_Request2;
 
 /**
  * Class for building multipart/form-data request body

--- a/src/FINDOLOGIC/HTTP_Request2/Observer/Log.php
+++ b/src/FINDOLOGIC/HTTP_Request2/Observer/Log.php
@@ -19,10 +19,11 @@
  * @link      http://pear.php.net/package/HTTP_Request2
  */
 
-/**
- * Exception class for HTTP_Request2 package
- */
-require_once 'HTTP/Request2/Exception.php';
+namespace FINDOLOGIC\HTTP_Request2\Observer;
+use FINDOLOGIC\HTTP_Request2\HTTP_Request2;
+use FINDOLOGIC\HTTP_Request2\HTTP_Request2_Exception;
+use SplObserver;
+use SplSubject;
 
 /**
  * A debug observer useful for debugging / testing.
@@ -32,10 +33,7 @@ require_once 'HTTP/Request2/Exception.php';
  * to log to a file or via the PEAR Log package.
  *
  * A simple example:
- * <code>
- * require_once 'HTTP/Request2.php';
- * require_once 'HTTP/Request2/Observer/Log.php';
- *
+ * <code> *
  * $request  = new HTTP_Request2('http://www.example.com');
  * $observer = new HTTP_Request2_Observer_Log();
  * $request->attach($observer);
@@ -43,11 +41,7 @@ require_once 'HTTP/Request2/Exception.php';
  * </code>
  *
  * A more complex example with PEAR Log:
- * <code>
- * require_once 'HTTP/Request2.php';
- * require_once 'HTTP/Request2/Observer/Log.php';
- * require_once 'Log.php';
- *
+ * <code> *
  * $request  = new HTTP_Request2('http://www.example.com');
  * // we want to log with PEAR log
  * $observer = new HTTP_Request2_Observer_Log(Log::factory('console'));

--- a/src/FINDOLOGIC/HTTP_Request2/Observer/UncompressingDownload.php
+++ b/src/FINDOLOGIC/HTTP_Request2/Observer/UncompressingDownload.php
@@ -19,7 +19,11 @@
  * @link      http://pear.php.net/package/HTTP_Request2
  */
 
-require_once 'HTTP/Request2/Response.php';
+namespace FINDOLOGIC\HTTP_Request2\Observer;
+use FINDOLOGIC\HTTP_Request2\HTTP_Request2_MessageException;
+use FINDOLOGIC\HTTP_Request2\HTTP_Request2_Response;
+use SplObserver;
+use SplSubject;
 
 /**
  * An observer that saves response body to stream, possibly uncompressing it
@@ -50,9 +54,6 @@ require_once 'HTTP/Request2/Response.php';
  * Example usage follows:
  *
  * <code>
- * require_once 'HTTP/Request2.php';
- * require_once 'HTTP/Request2/Observer/UncompressingDownload.php';
- *
  * #$inPath = 'http://carsten.codimi.de/gzip.yaws/daniels.html';
  * #$inPath = 'http://carsten.codimi.de/gzip.yaws/daniels.html?deflate=on';
  * $inPath = 'http://carsten.codimi.de/gzip.yaws/daniels.html?deflate=on&zlib=on';

--- a/src/FINDOLOGIC/HTTP_Request2/Request2.php
+++ b/src/FINDOLOGIC/HTTP_Request2/Request2.php
@@ -18,17 +18,15 @@
  * @link      http://pear.php.net/package/HTTP_Request2
  */
 
+namespace FINDOLOGIC\HTTP_Request2;
+
 /**
  * A class representing an URL as per RFC 3986.
  */
-if (!class_exists('Net_URL2', true)) {
-    require_once 'Net/URL2.php';
-}
-
-/**
- * Exception class for HTTP_Request2 package
- */
-require_once 'HTTP/Request2/Exception.php';
+use Exception;
+use Net_URL2;
+use SplObserver;
+use SplSubject;
 
 /**
  * Class representing a HTTP request message
@@ -623,7 +621,6 @@ class HTTP_Request2 implements SplSubject
                 return str_replace('%7E', '~', $body);
 
             } elseif (0 === strpos($this->headers['content-type'], 'multipart/form-data')) {
-                require_once 'HTTP/Request2/MultipartBody.php';
                 return new HTTP_Request2_MultipartBody(
                     $this->postParams, $this->uploads, $this->getConfig('use_brackets')
                 );
@@ -876,10 +873,6 @@ class HTTP_Request2 implements SplSubject
      */
     public function setCookieJar($jar = true)
     {
-        if (!class_exists('HTTP_Request2_CookieJar', false)) {
-            require_once 'HTTP/Request2/CookieJar.php';
-        }
-
         if ($jar instanceof HTTP_Request2_CookieJar) {
             $this->cookieJar = $jar;
         } elseif (true === $jar) {

--- a/src/FINDOLOGIC/HTTP_Request2/Response.php
+++ b/src/FINDOLOGIC/HTTP_Request2/Response.php
@@ -18,10 +18,9 @@
  * @link      http://pear.php.net/package/HTTP_Request2
  */
 
-/**
- * Exception class for HTTP_Request2 package
- */
-require_once 'HTTP/Request2/Exception.php';
+namespace FINDOLOGIC\HTTP_Request2;
+
+use Exception;
 
 /**
  * Class representing a HTTP response

--- a/src/FINDOLOGIC/HTTP_Request2/SOCKS5.php
+++ b/src/FINDOLOGIC/HTTP_Request2/SOCKS5.php
@@ -18,8 +18,7 @@
  * @link      http://pear.php.net/package/HTTP_Request2
  */
 
-/** Socket wrapper class used by Socket Adapter */
-require_once 'HTTP/Request2/SocketWrapper.php';
+namespace FINDOLOGIC\HTTP_Request2;
 
 /**
  * SOCKS5 proxy connection class (used by Socket Adapter)

--- a/src/FINDOLOGIC/HTTP_Request2/SocketWrapper.php
+++ b/src/FINDOLOGIC/HTTP_Request2/SocketWrapper.php
@@ -18,8 +18,7 @@
  * @link      http://pear.php.net/package/HTTP_Request2
  */
 
-/** Exception classes for HTTP_Request2 package */
-require_once 'HTTP/Request2/Exception.php';
+namespace FINDOLOGIC\HTTP_Request2;
 
 /**
  * Socket wrapper class used by Socket Adapter


### PR DESCRIPTION
Use PSR-4 namespaces to prevent autoloading issues that occur in some projects.